### PR TITLE
Admin Documentation: fix an example

### DIFF
--- a/admin/README.md
+++ b/admin/README.md
@@ -47,7 +47,7 @@ func main() {
   DB.AutoMigrate(&User{}, &Product{})
 
   // Initalize
-  Admin := admin.New(&admin.AdminConfig{DB: DB})
+  Admin := admin.New(&qor.Config{DB: DB})
 
   // Create resources from GORM-backend model
   Admin.AddResource(&User{})


### PR DESCRIPTION
I'm trying to use this example and I see that admin.AdminConfig doesn't exist in the current version of qor, it seems that we need qor.Config instead.