### PR TITLE
(fix) http router error when working with Gin

### DIFF
--- a/admin/integration.md
+++ b/admin/integration.md
@@ -27,7 +27,7 @@ mux := http.NewServeMux()
 Admin.MountTo("/admin", mux)
 
 r := gin.Default()
-r.Any("/admin/*", gin.WrapH(mux))
+r.Any("/admin/*resources", gin.WrapH(mux))
 r.Run()
 ```
 


### PR DESCRIPTION
If the name is missing, there would be a panic error. We can see in httprouter```panic("wildcards must be named with a non-empty name in path '" + fullPath + "'")```